### PR TITLE
remove border if never manipulated

### DIFF
--- a/src/components/camera/CameraView.js
+++ b/src/components/camera/CameraView.js
@@ -96,7 +96,8 @@ export default class CameraView extends Component {
             format: 'jpg',
             quality: .9,
             overlayOpacity: new Animated.Value(0),
-            showOverlay: false
+            showOverlay: false,
+            removeBorder: false
         };
     }
 
@@ -141,7 +142,8 @@ export default class CameraView extends Component {
             .then(picData => {
                 this.setState({
                     showOverlay: false,
-                    tmpScreen: picData.path
+                    tmpScreen: picData.path,
+                    removeBorder: true
                 });
             })
             .catch(err => console.log("ERROR", err));
@@ -176,7 +178,7 @@ export default class CameraView extends Component {
                 >
                     <View style={styles.fullScreen} ref={ref => this.setContainer(ref)}>
                         <Image style={styles.snapshot} source={source} onLoad={onLoad}>
-                            <ImageOverlay image={item.imageSource} />
+                            <ImageOverlay image={item.imageSource} removeBorder={this.state.removeBorder} />
                         </Image>
                     </View>
                 </Camera>

--- a/src/components/camera/ImageOverlay.js
+++ b/src/components/camera/ImageOverlay.js
@@ -184,7 +184,7 @@ export default class ImageOverlay extends Component {
     }
 
     render() {
-        const {image} = this.props;
+        const {image, removeBorder} = this.props;
         const pan = this._pan;
         const {
             isDragging, isScaling, overlayTouched,
@@ -206,7 +206,7 @@ export default class ImageOverlay extends Component {
         };
         const dragStyle = isDragging ? styles.dragging : null;
         const scaleStyle = isScaling ? styles.scaling : null;
-        const untouchedStyle = !overlayTouched ? styles.untouchedBorder : null;
+        const untouchedStyle = !overlayTouched && !removeBorder ? styles.untouchedBorder : null;
 
         return (
             <View style={styles.drag}>


### PR DESCRIPTION
@jrdrg @nivers if a user never manipulates the image overlay, the dotted border stays and shows up in the captured photo